### PR TITLE
ADD: diff:ignoreChildren and diff:ignoreAttributes comparers

### DIFF
--- a/src/AngleSharp.Diffing.Tests/Core/HtmlDifferenceEngineTest.cs
+++ b/src/AngleSharp.Diffing.Tests/Core/HtmlDifferenceEngineTest.cs
@@ -374,6 +374,23 @@ namespace AngleSharp.Diffing.Core
             results.ShouldBeEmpty();
         }
 
+        [Fact(DisplayName = "When comparer returns SkipAttributes from an element comparison, attributes are not compared")]
+        public void Test4()
+        {
+            var sut = CreateHtmlDiffer(
+                nodeMatcher: OneToOneNodeListMatcher,
+                nodeFilter: NoneNodeFilter,
+                nodeComparer: c => CompareResult.Same | CompareResult.SkipAttributes,
+                attrMatcher: AttributeNameMatcher,
+                attrFilter: NoneAttrFilter,
+                attrComparer: SameResultAttrComparer
+                );
+
+            var results = sut.Compare(ToNodeList(@"<p id=""foo""></p>"), ToNodeList(@"<p id=""bar"" unexpected></p>"));
+
+            results.ShouldBeEmpty();
+        }
+
         #region NodeFilters
         private static FilterDecision NoneNodeFilter(ComparisonSource source) => FilterDecision.Keep;
         private static FilterDecision RemoveCommentNodeFilter(ComparisonSource source) => source.Node.NodeType == NodeType.Comment ? FilterDecision.Exclude : FilterDecision.Keep;

--- a/src/AngleSharp.Diffing.Tests/Core/HtmlDifferenceEngineTest.cs
+++ b/src/AngleSharp.Diffing.Tests/Core/HtmlDifferenceEngineTest.cs
@@ -357,6 +357,23 @@ namespace AngleSharp.Diffing.Core
             results.ShouldBeEmpty();
         }
 
+        [Fact(DisplayName = "When comparer returns SkipChildren from an element comparison, the attributes are compared but child nodes not compared")]
+        public void Test3()
+        {
+            var sut = CreateHtmlDiffer(
+                nodeMatcher: OneToOneNodeListMatcher,
+                nodeFilter: NoneNodeFilter,
+                nodeComparer: c => c.Control.Node.NodeName == "P" ? CompareResult.Same | CompareResult.SkipChildren : throw new Exception("NODE COMPARER SHOULD NOT BE CALLED ON CHILD NODES"),
+                attrMatcher: AttributeNameMatcher,
+                attrFilter: NoneAttrFilter,
+                attrComparer: SameResultAttrComparer
+                );
+
+            var results = sut.Compare(ToNodeList(@"<p id=""bar""><em>foo</em></p>"), ToNodeList(@"<p id=""bar""><span>baz</span></p>"));
+
+            results.ShouldBeEmpty();
+        }
+
         #region NodeFilters
         private static FilterDecision NoneNodeFilter(ComparisonSource source) => FilterDecision.Keep;
         private static FilterDecision RemoveCommentNodeFilter(ComparisonSource source) => source.Node.NodeType == NodeType.Comment ? FilterDecision.Exclude : FilterDecision.Keep;

--- a/src/AngleSharp.Diffing.Tests/Core/HtmlDifferenceEngineTest.cs
+++ b/src/AngleSharp.Diffing.Tests/Core/HtmlDifferenceEngineTest.cs
@@ -357,7 +357,7 @@ namespace AngleSharp.Diffing.Core
             results.ShouldBeEmpty();
         }
 
-        [Fact(DisplayName = "When comparer returns SkipChildren from an element comparison, the attributes are compared but child nodes not compared")]
+        [Fact(DisplayName = "When comparer returns SkipChildren from an element comparison, child nodes are not compared")]
         public void Test3()
         {
             var sut = CreateHtmlDiffer(
@@ -369,7 +369,7 @@ namespace AngleSharp.Diffing.Core
                 attrComparer: SameResultAttrComparer
                 );
 
-            var results = sut.Compare(ToNodeList(@"<p id=""bar""><em>foo</em></p>"), ToNodeList(@"<p id=""bar""><span>baz</span></p>"));
+            var results = sut.Compare(ToNodeList(@"<p><em>foo</em></p>"), ToNodeList(@"<p><span>baz</span></p>"));
 
             results.ShouldBeEmpty();
         }

--- a/src/AngleSharp.Diffing.Tests/Core/HtmlDifferenceEngineTest.cs
+++ b/src/AngleSharp.Diffing.Tests/Core/HtmlDifferenceEngineTest.cs
@@ -357,13 +357,15 @@ namespace AngleSharp.Diffing.Core
             results.ShouldBeEmpty();
         }
 
-        [Fact(DisplayName = "When comparer returns SkipChildren from an element comparison, child nodes are not compared")]
-        public void Test3()
+        [Theory(DisplayName = "When comparer returns SkipChildren flag from an element comparison, child nodes are not compared")]
+        [InlineData(CompareResult.Same | CompareResult.SkipChildren)]
+        [InlineData(CompareResult.Skip | CompareResult.SkipChildren)]
+        public void Test3(CompareResult compareResult)
         {
             var sut = CreateHtmlDiffer(
                 nodeMatcher: OneToOneNodeListMatcher,
                 nodeFilter: NoneNodeFilter,
-                nodeComparer: c => c.Control.Node.NodeName == "P" ? CompareResult.Same | CompareResult.SkipChildren : throw new Exception("NODE COMPARER SHOULD NOT BE CALLED ON CHILD NODES"),
+                nodeComparer: c => c.Control.Node.NodeName == "P" ? compareResult : throw new Exception("NODE COMPARER SHOULD NOT BE CALLED ON CHILD NODES"),
                 attrMatcher: AttributeNameMatcher,
                 attrFilter: NoneAttrFilter,
                 attrComparer: SameResultAttrComparer
@@ -374,13 +376,15 @@ namespace AngleSharp.Diffing.Core
             results.ShouldBeEmpty();
         }
 
-        [Fact(DisplayName = "When comparer returns SkipAttributes from an element comparison, attributes are not compared")]
-        public void Test4()
+        [Theory(DisplayName = "When comparer returns SkipAttributes flag from an element comparison, attributes are not compared")]
+        [InlineData(CompareResult.Same | CompareResult.SkipAttributes)]
+        [InlineData(CompareResult.Skip | CompareResult.SkipAttributes)]
+        public void Test4(CompareResult compareResult)
         {
             var sut = CreateHtmlDiffer(
                 nodeMatcher: OneToOneNodeListMatcher,
                 nodeFilter: NoneNodeFilter,
-                nodeComparer: c => CompareResult.Same | CompareResult.SkipAttributes,
+                nodeComparer: c => compareResult,
                 attrMatcher: AttributeNameMatcher,
                 attrFilter: NoneAttrFilter,
                 attrComparer: SameResultAttrComparer

--- a/src/AngleSharp.Diffing.Tests/DiffBuilderTest.cs
+++ b/src/AngleSharp.Diffing.Tests/DiffBuilderTest.cs
@@ -89,5 +89,41 @@ namespace AngleSharp.Diffing
             nodeComparerCalled.ShouldBeTrue();
             attrComparerCalled.ShouldBeTrue();
         }
+
+        [Theory(DisplayName = "When a control element has 'diff:ignoreChildren', calling Build() with DefaultOptions() returns empty diffs")]
+        [InlineData(@"<p diff:ignoreChildren>hello <em>world</em></p>",
+                         @"<p>world says <strong>hello</strong></p>")]
+        [InlineData(@"<p diff:ignoreChildren>hello</p>",
+                         @"<p>world says <strong>hello</strong></p>")]
+        [InlineData(@"<p diff:ignoreChildren>hello <em>world</em></p>",
+                         @"<p>world says</p>")]
+        public void Test005(string control, string test)
+        {
+            var diffs = DiffBuilder
+                .Compare(control)
+                .WithTest(test)
+                .Build()
+                .ToList();
+
+            diffs.ShouldBeEmpty();
+        }
+
+        [Theory(DisplayName = "When a control element has 'diff:ignoreAttributes', calling Build() with DefaultOptions() returns empty diffs")]
+        [InlineData(@"<p id=""foo"" diff:ignoreAttributes></p>",
+                         @"<p id=""bar""></p>")]
+        [InlineData(@"<p diff:ignoreAttributes></p>",
+                         @"<p unexpected></p>")]
+        [InlineData(@"<p id=""foo"" diff:ignoreAttributes></p>",
+                         @"<p></p>")]
+        public void Test006(string control, string test)
+        {
+            var diffs = DiffBuilder
+                .Compare(control)
+                .WithTest(test)
+                .Build()
+                .ToList();
+
+            diffs.ShouldBeEmpty();
+        }
     }
 }

--- a/src/AngleSharp.Diffing.Tests/Strategies/ElementStrategies/IgnoreAttributesElementComparerTest.cs
+++ b/src/AngleSharp.Diffing.Tests/Strategies/ElementStrategies/IgnoreAttributesElementComparerTest.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+
+using AngleSharp.Diffing.Core;
+
+using Shouldly;
+
+using Xunit;
+
+namespace AngleSharp.Diffing.Strategies.ElementStrategies
+{
+    public class IgnoreAttributesElementComparerTest : DiffingTestBase
+    {
+        public IgnoreAttributesElementComparerTest(DiffingTestFixture fixture) : base(fixture)
+        {
+        }
+
+        [Theory(DisplayName = "When a control element does not contain the 'diff:ignoreAttributes' attribute or it is 'diff:ignoreAttributes=false', the current decision is returned")]
+        [InlineData(@"<p></p>")]
+        [InlineData(@"<p diff:ignoreAttributes=""false""></p>")]
+        [InlineData(@"<p diff:ignoreAttributes=""FALSE""></p>")]
+        [InlineData(@"<p diff:ignoreAttributes=""faLsE""></p>")]
+        public void Test001(string controlHtml)
+        {
+            var comparison = ToComparison(controlHtml, "<p></p>");
+
+            IgnoreAttributesElementComparer.Compare(comparison, CompareResult.Different).ShouldBe(CompareResult.Different);
+            IgnoreAttributesElementComparer.Compare(comparison, CompareResult.Same).ShouldBe(CompareResult.Same);
+            IgnoreAttributesElementComparer.Compare(comparison, CompareResult.Skip).ShouldBe(CompareResult.Skip);
+        }
+
+        [Theory(DisplayName = "When a control element has 'diff:ignoreAttributes' attribute, CompareResult.SkipAttributes flag is returned")]
+        [InlineData(@"<p diff:ignoreAttributes></p>")]
+        [InlineData(@"<p diff:ignoreAttributes=""true""></p>")]
+        [InlineData(@"<p diff:ignoreAttributes=""TRUE""></p>")]
+        [InlineData(@"<p diff:ignoreAttributes=""TrUe""></p>")]
+        public void Test002(string controlHtml)
+        {
+            var comparison = ToComparison(controlHtml, "<p></p>");
+
+            IgnoreAttributesElementComparer.Compare(comparison, CompareResult.Same).ShouldBe(CompareResult.Same | CompareResult.SkipAttributes);
+            IgnoreAttributesElementComparer.Compare(comparison, CompareResult.Different).ShouldBe(CompareResult.Different | CompareResult.SkipAttributes);
+        }
+    }
+}

--- a/src/AngleSharp.Diffing.Tests/Strategies/ElementStrategies/IgnoreChildrenElementComparerTest.cs
+++ b/src/AngleSharp.Diffing.Tests/Strategies/ElementStrategies/IgnoreChildrenElementComparerTest.cs
@@ -21,7 +21,7 @@ namespace AngleSharp.Diffing.Strategies.ElementStrategies
         [InlineData(@"<p diff:ignoreChildren=""faLsE""></p>")]
         public void Test001(string controlHtml)
         {
-            var comparison = ToComparison(controlHtml, "<p><em></em></p>");
+            var comparison = ToComparison(controlHtml, "<p></p>");
 
             IgnoreChildrenElementComparer.Compare(comparison, CompareResult.Different).ShouldBe(CompareResult.Different);
             IgnoreChildrenElementComparer.Compare(comparison, CompareResult.Same).ShouldBe(CompareResult.Same);
@@ -35,28 +35,10 @@ namespace AngleSharp.Diffing.Strategies.ElementStrategies
         [InlineData(@"<p diff:ignoreChildren=""TrUe""></p>")]
         public void Test002(string controlHtml)
         {
-            var comparison = ToComparison(controlHtml, "<p><em></em></p>");
+            var comparison = ToComparison(controlHtml, "<p></p>");
 
             IgnoreChildrenElementComparer.Compare(comparison, CompareResult.Same).ShouldBe(CompareResult.Same | CompareResult.SkipChildren);
             IgnoreChildrenElementComparer.Compare(comparison, CompareResult.Different).ShouldBe(CompareResult.Different | CompareResult.SkipChildren);
-        }
-
-        [Theory(DisplayName = "When a control element has 'diff:ignoreChildren', calling Build() with DefaultOptions() returns empty diffs")]
-        [InlineData(@"<p diff:ignoreChildren>hello <em>world</em></p>",
-                         @"<p>world says <strong>hello</strong></p>")]
-        [InlineData(@"<p diff:ignoreChildren>hello</p>",
-                         @"<p>world says <strong>hello</strong></p>")]
-        [InlineData(@"<p diff:ignoreChildren>hello <em>world</em></p>",
-                         @"<p>world says</p>")]
-        public void Test004(string control, string test)
-        {
-            var diffs = DiffBuilder
-                .Compare(control)
-                .WithTest(test)
-                .Build()
-                .ToList();
-
-            diffs.ShouldBeEmpty();
         }
     }
 }

--- a/src/AngleSharp.Diffing.Tests/Strategies/ElementStrategies/IgnoreChildrenElementComparerTest.cs
+++ b/src/AngleSharp.Diffing.Tests/Strategies/ElementStrategies/IgnoreChildrenElementComparerTest.cs
@@ -28,7 +28,7 @@ namespace AngleSharp.Diffing.Strategies.ElementStrategies
             IgnoreChildrenElementComparer.Compare(comparison, CompareResult.Skip).ShouldBe(CompareResult.Skip);
         }
 
-        [Theory(DisplayName = "When a control element has 'diff:ignoreChildren' attribute, SameAndBreak is returned")]
+        [Theory(DisplayName = "When a control element has 'diff:ignoreChildren' attribute, CompareResult.SkipChildren flag is returned")]
         [InlineData(@"<p diff:ignoreChildren></p>")]
         [InlineData(@"<p diff:ignoreChildren=""true""></p>")]
         [InlineData(@"<p diff:ignoreChildren=""TRUE""></p>")]
@@ -41,29 +41,13 @@ namespace AngleSharp.Diffing.Strategies.ElementStrategies
             IgnoreChildrenElementComparer.Compare(comparison, CompareResult.Different).ShouldBe(CompareResult.Different | CompareResult.SkipChildren);
         }
 
-        [Fact(DisplayName = "When a control element has 'diff:ignoreChildren', calling Build() with DefaultOptions() returns expected diffs")]
-        public void Test003()
-        {
-            var control = @"<p attr=""foo"" missing diff:ignoreChildren>hello <em>world</em></p>";
-            var test    = @"<p attr=""bar"" unexpected>world says <strong>hello</strong></p>";
-
-            var diffs = DiffBuilder
-                .Compare(control)
-                .WithTest(test)
-                .Build()
-                .ToList();
-
-            diffs.Count.ShouldBe(3);
-            diffs.SingleOrDefault(x => x is AttrDiff).ShouldNotBeNull();
-            diffs.SingleOrDefault(x => x is MissingAttrDiff).ShouldNotBeNull();
-            diffs.SingleOrDefault(x => x is UnexpectedAttrDiff).ShouldNotBeNull();
-        }
-
         [Theory(DisplayName = "When a control element has 'diff:ignoreChildren', calling Build() with DefaultOptions() returns empty diffs")]
-        [InlineData(@"<p attr=""foo"" diff:ignoreChildren>hello <em>world</em></p>",
-                        @"<p attr=""foo"">world says <strong>hello</strong></p>")]
-        [InlineData(@"<p attr=""foo"" expected diff:ignoreChildren>hello <em>world</em></p>",
-                        @"<p attr=""foo"" expected>world says <strong>hello</strong></p>")]
+        [InlineData(@"<p diff:ignoreChildren>hello <em>world</em></p>",
+                         @"<p>world says <strong>hello</strong></p>")]
+        [InlineData(@"<p diff:ignoreChildren>hello</p>",
+                         @"<p>world says <strong>hello</strong></p>")]
+        [InlineData(@"<p diff:ignoreChildren>hello <em>world</em></p>",
+                         @"<p>world says</p>")]
         public void Test004(string control, string test)
         {
             var diffs = DiffBuilder

--- a/src/AngleSharp.Diffing.Tests/Strategies/ElementStrategies/IgnoreChildrenElementComparerTest.cs
+++ b/src/AngleSharp.Diffing.Tests/Strategies/ElementStrategies/IgnoreChildrenElementComparerTest.cs
@@ -1,0 +1,78 @@
+using System.Linq;
+
+using AngleSharp.Diffing.Core;
+
+using Shouldly;
+
+using Xunit;
+
+namespace AngleSharp.Diffing.Strategies.ElementStrategies
+{
+    public class IgnoreChildrenElementComparerTest : DiffingTestBase
+    {
+        public IgnoreChildrenElementComparerTest(DiffingTestFixture fixture) : base(fixture)
+        {
+        }
+
+        [Theory(DisplayName = "When a control element does not contain the 'diff:ignoreChildren' attribute or it is 'diff:ignoreChildren=false', the current decision is returned")]
+        [InlineData(@"<p></p>")]
+        [InlineData(@"<p diff:ignoreChildren=""false""></p>")]
+        [InlineData(@"<p diff:ignoreChildren=""FALSE""></p>")]
+        [InlineData(@"<p diff:ignoreChildren=""faLsE""></p>")]
+        public void Test001(string controlHtml)
+        {
+            var comparison = ToComparison(controlHtml, "<p><em></em></p>");
+
+            IgnoreChildrenElementComparer.Compare(comparison, CompareResult.Different).ShouldBe(CompareResult.Different);
+            IgnoreChildrenElementComparer.Compare(comparison, CompareResult.Same).ShouldBe(CompareResult.Same);
+            IgnoreChildrenElementComparer.Compare(comparison, CompareResult.Skip).ShouldBe(CompareResult.Skip);
+        }
+
+        [Theory(DisplayName = "When a control element has 'diff:ignoreChildren' attribute, SameAndBreak is returned")]
+        [InlineData(@"<p diff:ignoreChildren></p>")]
+        [InlineData(@"<p diff:ignoreChildren=""true""></p>")]
+        [InlineData(@"<p diff:ignoreChildren=""TRUE""></p>")]
+        [InlineData(@"<p diff:ignoreChildren=""TrUe""></p>")]
+        public void Test002(string controlHtml)
+        {
+            var comparison = ToComparison(controlHtml, "<p><em></em></p>");
+
+            IgnoreChildrenElementComparer.Compare(comparison, CompareResult.Same).ShouldBe(CompareResult.Same | CompareResult.SkipChildren);
+            IgnoreChildrenElementComparer.Compare(comparison, CompareResult.Different).ShouldBe(CompareResult.Different | CompareResult.SkipChildren);
+        }
+
+        [Fact(DisplayName = "When a control element has 'diff:ignoreChildren', calling Build() with DefaultOptions() returns expected diffs")]
+        public void Test003()
+        {
+            var control = @"<p attr=""foo"" missing diff:ignoreChildren>hello <em>world</em></p>";
+            var test    = @"<p attr=""bar"" unexpected>world says <strong>hello</strong></p>";
+
+            var diffs = DiffBuilder
+                .Compare(control)
+                .WithTest(test)
+                .Build()
+                .ToList();
+
+            diffs.Count.ShouldBe(3);
+            diffs.SingleOrDefault(x => x is AttrDiff).ShouldNotBeNull();
+            diffs.SingleOrDefault(x => x is MissingAttrDiff).ShouldNotBeNull();
+            diffs.SingleOrDefault(x => x is UnexpectedAttrDiff).ShouldNotBeNull();
+        }
+
+        [Theory(DisplayName = "When a control element has 'diff:ignoreChildren', calling Build() with DefaultOptions() returns empty diffs")]
+        [InlineData(@"<p attr=""foo"" diff:ignoreChildren>hello <em>world</em></p>",
+                        @"<p attr=""foo"">world says <strong>hello</strong></p>")]
+        [InlineData(@"<p attr=""foo"" expected diff:ignoreChildren>hello <em>world</em></p>",
+                        @"<p attr=""foo"" expected>world says <strong>hello</strong></p>")]
+        public void Test004(string control, string test)
+        {
+            var diffs = DiffBuilder
+                .Compare(control)
+                .WithTest(test)
+                .Build()
+                .ToList();
+
+            diffs.ShouldBeEmpty();
+        }
+    }
+}

--- a/src/AngleSharp.Diffing/Core/CompareResult.cs
+++ b/src/AngleSharp.Diffing/Core/CompareResult.cs
@@ -1,22 +1,29 @@
-﻿namespace AngleSharp.Diffing.Core
+﻿using System;
+
+namespace AngleSharp.Diffing.Core
 {
     /// <summary>
     /// Represents a result of a comparison.
     /// </summary>
+    [Flags]
     public enum CompareResult
     {
         /// <summary>
         /// Use when the two compared nodes or attributes are the same.
         /// </summary>
-        Same,
+        Same = 1,
         /// <summary>
         /// Use when the two compared nodes or attributes are the different.
         /// </summary>
-        Different,
+        Different = 2,
         /// <summary>
         /// Use when the comparison should be skipped and any child-nodes or attributes skipped as well.
         /// </summary>
-        Skip
+        Skip = 4,
+        /// <summary>
+        /// Use when the comparison should skip any child-nodes.
+        /// </summary>
+        SkipChildren = 8,
     }
 
     /// <summary>

--- a/src/AngleSharp.Diffing/Core/CompareResult.cs
+++ b/src/AngleSharp.Diffing/Core/CompareResult.cs
@@ -24,6 +24,10 @@ namespace AngleSharp.Diffing.Core
         /// Use when the comparison should skip any child-nodes.
         /// </summary>
         SkipChildren = 8,
+        /// <summary>
+        /// Use when the comparison should skip any attributes.
+        /// </summary>
+        SkipAttributes = 16,
     }
 
     /// <summary>

--- a/src/AngleSharp.Diffing/Core/HtmlDifferenceEngine.cs
+++ b/src/AngleSharp.Diffing/Core/HtmlDifferenceEngine.cs
@@ -113,7 +113,8 @@ namespace AngleSharp.Diffing.Core
 
             if (compareRes != CompareResult.Skip)
             {
-                result.AddRange(CompareElementAttributes(comparison));
+                if (!compareRes.HasFlag(CompareResult.SkipAttributes))
+                    result.AddRange(CompareElementAttributes(comparison));
                 if (!compareRes.HasFlag(CompareResult.SkipChildren))
                     result.AddRange(CompareChildNodes(comparison));
             }

--- a/src/AngleSharp.Diffing/Core/HtmlDifferenceEngine.cs
+++ b/src/AngleSharp.Diffing/Core/HtmlDifferenceEngine.cs
@@ -92,7 +92,7 @@ namespace AngleSharp.Diffing.Core
             }
 
             var compareRes = _diffingStrategy.Compare(comparison);
-            if (compareRes == CompareResult.Different)
+            if (compareRes.HasFlag(CompareResult.Different))
             {
                 IDiff diff = new NodeDiff(comparison);
                 return new[] { diff };
@@ -106,7 +106,7 @@ namespace AngleSharp.Diffing.Core
             var result = new List<IDiff>();
 
             var compareRes = _diffingStrategy.Compare(comparison);
-            if (compareRes == CompareResult.Different)
+            if (compareRes.HasFlag(CompareResult.Different))
             {
                 result.Add(new NodeDiff(comparison));
             }
@@ -114,7 +114,8 @@ namespace AngleSharp.Diffing.Core
             if (compareRes != CompareResult.Skip)
             {
                 result.AddRange(CompareElementAttributes(comparison));
-                result.AddRange(CompareChildNodes(comparison));
+                if (!compareRes.HasFlag(CompareResult.SkipChildren))
+                    result.AddRange(CompareChildNodes(comparison));
             }
 
             return result;

--- a/src/AngleSharp.Diffing/Core/HtmlDifferenceEngine.cs
+++ b/src/AngleSharp.Diffing/Core/HtmlDifferenceEngine.cs
@@ -111,7 +111,7 @@ namespace AngleSharp.Diffing.Core
                 result.Add(new NodeDiff(comparison));
             }
 
-            if (compareRes != CompareResult.Skip)
+            if (!compareRes.HasFlag(CompareResult.Skip))
             {
                 if (!compareRes.HasFlag(CompareResult.SkipAttributes))
                     result.AddRange(CompareElementAttributes(comparison));

--- a/src/AngleSharp.Diffing/Strategies/DiffingStrategyPipelineBuilderExtensions.cs
+++ b/src/AngleSharp.Diffing/Strategies/DiffingStrategyPipelineBuilderExtensions.cs
@@ -19,13 +19,15 @@ namespace AngleSharp.Diffing
                 .AddAttributeNameMatcher()
                 .AddElementComparer()
                 .AddIgnoreElementSupport()
-                .AddIgnoreChildrenElementSupport()
                 .AddStyleSheetComparer()
                 .AddTextComparer(WhitespaceOption.Normalize, ignoreCase: false)
                 .AddAttributeComparer()
                 .AddClassAttributeComparer()
                 .AddBooleanAttributeComparer(BooleanAttributeComparision.Strict)
-                .AddStyleAttributeComparer();
+                .AddStyleAttributeComparer()
+                .AddIgnoreChildrenElementSupport()
+                .AddIgnoreAttributesElementSupport()
+                ;
         }
     }
 }

--- a/src/AngleSharp.Diffing/Strategies/DiffingStrategyPipelineBuilderExtensions.cs
+++ b/src/AngleSharp.Diffing/Strategies/DiffingStrategyPipelineBuilderExtensions.cs
@@ -19,13 +19,13 @@ namespace AngleSharp.Diffing
                 .AddAttributeNameMatcher()
                 .AddElementComparer()
                 .AddIgnoreElementSupport()
+                .AddIgnoreChildrenElementSupport()
                 .AddStyleSheetComparer()
                 .AddTextComparer(WhitespaceOption.Normalize, ignoreCase: false)
                 .AddAttributeComparer()
                 .AddClassAttributeComparer()
                 .AddBooleanAttributeComparer(BooleanAttributeComparision.Strict)
                 .AddStyleAttributeComparer();
-            ;
         }
     }
 }

--- a/src/AngleSharp.Diffing/Strategies/ElementStrategies/DiffingStrategyPipelineBuilderExtensions.cs
+++ b/src/AngleSharp.Diffing/Strategies/ElementStrategies/DiffingStrategyPipelineBuilderExtensions.cs
@@ -33,5 +33,16 @@ namespace AngleSharp.Diffing
             builder.AddComparer(IgnoreElementComparer.Compare, StrategyType.Specialized);
             return builder;
         }
+
+        /// <summary>
+        /// Enables the ignore children element `diff:ignorechildren` attribute during diffing.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public static IDiffingStrategyCollection AddIgnoreChildrenElementSupport(this IDiffingStrategyCollection builder)
+        {
+            builder.AddComparer(IgnoreChildrenElementComparer.Compare, StrategyType.Specialized);
+            return builder;
+        }
     }
 }

--- a/src/AngleSharp.Diffing/Strategies/ElementStrategies/DiffingStrategyPipelineBuilderExtensions.cs
+++ b/src/AngleSharp.Diffing/Strategies/ElementStrategies/DiffingStrategyPipelineBuilderExtensions.cs
@@ -35,13 +35,24 @@ namespace AngleSharp.Diffing
         }
 
         /// <summary>
-        /// Enables the ignore children element `diff:ignorechildren` attribute during diffing.
+        /// Enables the ignore children element `diff:ignoreChildren` attribute during diffing.
         /// </summary>
         /// <param name="builder"></param>
         /// <returns></returns>
         public static IDiffingStrategyCollection AddIgnoreChildrenElementSupport(this IDiffingStrategyCollection builder)
         {
             builder.AddComparer(IgnoreChildrenElementComparer.Compare, StrategyType.Specialized);
+            return builder;
+        }
+
+        /// <summary>
+        /// Enables the ignore attributes element `diff:ignoreAttributes` attribute during diffing.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public static IDiffingStrategyCollection AddIgnoreAttributesElementSupport(this IDiffingStrategyCollection builder)
+        {
+            builder.AddComparer(IgnoreAttributesElementComparer.Compare, StrategyType.Specialized);
             return builder;
         }
     }

--- a/src/AngleSharp.Diffing/Strategies/ElementStrategies/IgnoreAttributesElementComparer.cs
+++ b/src/AngleSharp.Diffing/Strategies/ElementStrategies/IgnoreAttributesElementComparer.cs
@@ -5,29 +5,29 @@ using AngleSharp.Dom;
 namespace AngleSharp.Diffing.Strategies.ElementStrategies
 {
     /// <summary>
-    /// Represents the ignore children element comparer.
+    /// Represents the ignore attributes element comparer.
     /// </summary>
-    public static class IgnoreChildrenElementComparer
+    public static class IgnoreAttributesElementComparer
     {
-        private const string DIFF_IGNORE_CHILDREN_ATTRIBUTE = "diff:ignorechildren";
+        private const string DIFF_IGNORE_ATTRIBUTES_ATTRIBUTE = "diff:ignoreattributes";
 
         /// <summary>
-        /// The ignore children element comparer.
+        /// The ignore attributes element comparer.
         /// </summary>
         public static CompareResult Compare(in Comparison comparison, CompareResult currentDecision)
         {
             if (currentDecision == CompareResult.Skip)
                 return currentDecision;
 
-            return ControlHasTruthyIgnoreChildrenAttribute(comparison)
-                ? currentDecision | CompareResult.SkipChildren
+            return ControlHasTruthyIgnoreAttributesAttribute(comparison)
+                ? currentDecision | CompareResult.SkipAttributes
                 : currentDecision;
         }
 
-        private static bool ControlHasTruthyIgnoreChildrenAttribute(in Comparison comparison)
+        private static bool ControlHasTruthyIgnoreAttributesAttribute(in Comparison comparison)
         {
             return comparison.Control.Node is IElement element &&
-                    element.TryGetAttrValue(DIFF_IGNORE_CHILDREN_ATTRIBUTE, out bool shouldIgnore) &&
+                    element.TryGetAttrValue(DIFF_IGNORE_ATTRIBUTES_ATTRIBUTE, out bool shouldIgnore) &&
                     shouldIgnore;
         }
     }

--- a/src/AngleSharp.Diffing/Strategies/ElementStrategies/IgnoreChildrenElementComparer.cs
+++ b/src/AngleSharp.Diffing/Strategies/ElementStrategies/IgnoreChildrenElementComparer.cs
@@ -1,0 +1,34 @@
+using AngleSharp.Diffing.Core;
+using AngleSharp.Diffing.Extensions;
+using AngleSharp.Dom;
+
+namespace AngleSharp.Diffing.Strategies.ElementStrategies
+{
+    /// <summary>
+    /// Represents the ignore children element comparer.
+    /// </summary>
+    public static class IgnoreChildrenElementComparer
+    {
+        private const string DIFF_IGNORE_CHILDREN_ATTRIBUTE = "diff:ignorechildren";
+
+        /// <summary>
+        /// The ignore children element comparer.
+        /// </summary>
+        public static CompareResult Compare(in Comparison comparison, CompareResult currentDecision)
+        {
+            if (currentDecision == CompareResult.Skip)
+                return currentDecision;
+
+            return ControlHasTruthyIgnoreAttribute(comparison)
+                ? currentDecision | CompareResult.SkipChildren
+                : currentDecision;
+        }
+
+        private static bool ControlHasTruthyIgnoreAttribute(in Comparison comparison)
+        {
+            return comparison.Control.Node is IElement element &&
+                    element.TryGetAttrValue(DIFF_IGNORE_CHILDREN_ATTRIBUTE, out bool shouldIgnore) &&
+                    shouldIgnore;
+        }
+    }
+}


### PR DESCRIPTION
# Types of Changes
Added 'diff:ignoreChildren' comparer.
Now there is the ability to ignore an elements children (see #9). 

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

I can update documentation after accepting PR.
