### PR TITLE
Fix textnode path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.18.0
+
+Released on Tuesday, February 15, 2022.
+
+- Added a new style comparer which orders the styles before comparing them. By [@grishat](https://github.com/SebastianStehle).
+- Change Core.ComparisonSource.GetPathIndex() to return the index inside ChildNodes instead of Children. By [@edxlhornung](https://github.com/edxlhornung).
+
 # 0.17.0
 
 Released on Wednesday, September 8, 2021.

--- a/src/AngleSharp.Diffing.Tests/Core/ComparisonSourceTest.cs
+++ b/src/AngleSharp.Diffing.Tests/Core/ComparisonSourceTest.cs
@@ -68,12 +68,13 @@ namespace AngleSharp.Diffing.Core
         }
 
         [Theory(DisplayName = "The index in the source's path is based on its position in it's parents" +
-            "child node list, i.e. excluding other node types that does not contain children")]
+            "child node list")]
         [InlineData("<p>", 0, "p(0)")]
-        [InlineData("text<p>", 1, "p(0)")]
-        [InlineData("<!--x--><p>", 1, "p(0)")]
-        [InlineData("<i></i>text<p>", 2, "p(1)")]
-        [InlineData("<i></i><!--x--><p>", 2, "p(1)")]
+        [InlineData("text<p>", 1, "p(1)")]
+        [InlineData("<!--x--><p>", 1, "p(1)")]
+        [InlineData("<i></i>text<p>", 2, "p(2)")]
+        [InlineData("<i></i><!--x--><p>", 2, "p(2)")]
+        [InlineData("<i></i>text<!--x--><p>text", 2, "#comment(2)")]
         public void Test005(string sourceMarkup, int nodeIndex, string expectedPath)
         {
             var node = ToNodeList(sourceMarkup)[nodeIndex];
@@ -91,7 +92,7 @@ namespace AngleSharp.Diffing.Core
 
             var sut = new ComparisonSource(textNode, ComparisonSourceType.Control);
 
-            sut.Path.ShouldBe("p(0) > i(1) > #text(0)");
+            sut.Path.ShouldBe("p(0) > i(2) > #text(0)");
         }
 
         [Fact(DisplayName = "Source uses parent path if provided to construct own path")]

--- a/src/AngleSharp.Diffing/Core/ComparisonSource.cs
+++ b/src/AngleSharp.Diffing/Core/ComparisonSource.cs
@@ -118,7 +118,6 @@ namespace AngleSharp.Diffing.Core
 
         private static int GetPathIndex(INode node)
         {
-            var result = 0;
             var parent = node.Parent;
             if (parent is not null)
             {
@@ -126,9 +125,7 @@ namespace AngleSharp.Diffing.Core
                 for (int index = 0; index < childNodes.Length; index++)
                 {
                     if (ReferenceEquals(childNodes[index], node))
-                        return result;
-                    if (childNodes[index] is IParentNode)
-                        result += 1;
+                        return index;
                 }
             }
             throw new InvalidOperationException("Unexpected node tree state. The node was not found in its parents child nodes collection.");

--- a/tools/anglesharp.cake
+++ b/tools/anglesharp.cake
@@ -1,5 +1,5 @@
-#addin "Cake.FileHelpers"
-#addin "Octokit"
+#addin nuget:?package=Cake.FileHelpers&version=3.2.0
+#addin nuget:?package=Octokit&version=0.32.0
 using Octokit;
 
 var configuration = Argument("configuration", "Release");

--- a/tools/anglesharp.cake
+++ b/tools/anglesharp.cake
@@ -1,4 +1,4 @@
-#addin nuget:?package=Cake.FileHelpers&version=3.2.0
+#addin nuget:?package=Cake.FileHelpers&version=4.0.1
 #addin nuget:?package=Octokit&version=0.32.0
 using Octokit;
 


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed

## Description

Please see #20 as it contains a good description of the problem and the implementation I did.

The issue was that the index of nodes without children (text and comment) present in the path property of diff nodes was incorrect. This is due to Core.ComparisonSource.GetPathIndex() returning the index inside the Children property (Which does not show nodes without children) instead of the ChildNodes property.

Thus I changed Core.ComparisonSource.GetPathIndex() to return the index inside ChildNodes. I also had to adjust the corresponding test cases in order to accommodate this new change.
