### PR TITLE
Fix - compare node names case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-# 0.18.0
+# 0.17.1
 
-Released on Tuesday, February 15, 2022.
+Released on Friday, February 3, 2023.
 
 - Added a new style comparer which orders the styles before comparing them. By [@grishat](https://github.com/SebastianStehle).
 - Change Core.ComparisonSource.GetPathIndex() to return the index inside ChildNodes instead of Children. By [@edxlhornung](https://github.com/edxlhornung).
+- Fixed element comparison such that it uses case insensitive comparison of the name of the node. By [@egil](https://github.com/egil).
 
 # 0.17.0
 

--- a/src/AngleSharp.Diffing.Tests/AngleSharp.DiffingTests.csproj
+++ b/src/AngleSharp.Diffing.Tests/AngleSharp.DiffingTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>AngleSharp.Diffing.Tests</AssemblyName>
     <RootNamespace>AngleSharp.Diffing</RootNamespace>
@@ -10,15 +10,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
-    <PackageReference Include="Shouldly" Version="4.0.3" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="Shouldly" Version="4.1.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/AngleSharp.Diffing.Tests/Strategies/NodeStrategies/ForwardSearchingNodeMatcherTest.cs
+++ b/src/AngleSharp.Diffing.Tests/Strategies/NodeStrategies/ForwardSearchingNodeMatcherTest.cs
@@ -17,8 +17,11 @@ namespace AngleSharp.Diffing.Strategies.NodeStrategies
 
         [Theory(DisplayName = "The matcher matches two nodes with the same node name")]
         [InlineData("textnode", "textnode")]
-        [InlineData("<!--comment-->", "<!--comment-->")]
         [InlineData("<p></p>", "<p></p>")]
+        [InlineData("<!--comment-->", "<!--comment-->")]
+        [InlineData("<!-- [endif] -->", "<!-- [endif] -->")]
+        [InlineData("<!-- -->", "<!-- -->")]
+        [InlineData("<!---->", "<!---->")]
         public void Test001(string controlHtml, string testHtml)
         {
             var controls = ToSourceCollection(controlHtml, ComparisonSourceType.Control);

--- a/src/AngleSharp.Diffing.Tests/Strategies/NodeStrategies/NodeComparerTest.cs
+++ b/src/AngleSharp.Diffing.Tests/Strategies/NodeStrategies/NodeComparerTest.cs
@@ -1,4 +1,6 @@
-﻿using AngleSharp.Diffing.Core;
+﻿using System;
+
+using AngleSharp.Diffing.Core;
 using AngleSharp.Diffing.Strategies.ElementStrategies;
 
 using Shouldly;
@@ -29,6 +31,17 @@ namespace AngleSharp.Diffing.Strategies.NodeStrategies
         {
             var comparison = ToComparison(controlHtml, testHtml);
             ElementComparer.Compare(comparison, CompareResult.Unknown).ShouldBe(CompareResult.Different);
+        }
+
+        [Theory(DisplayName = "When unknown node is used in comparison, but node name is equal, the result is Same")]
+        [InlineData("<svg><path></path></svg>", "<path/>")]
+        public void HandleUnknownNodeDuringComparison(string controlHtml, string testHtml)
+        {
+            var knownNode = ToNode(controlHtml).FirstChild.ToComparisonSource(0, ComparisonSourceType.Control);
+            var unknownNode = ToNode(testHtml).ToComparisonSource(0, ComparisonSourceType.Test);
+            var comparison = new Comparison(knownNode, unknownNode);
+            
+            ElementComparer.Compare(comparison, CompareResult.Unknown).ShouldBe(CompareResult.Same);
         }
     }
 }

--- a/src/AngleSharp.Diffing/Core/Comparison.cs
+++ b/src/AngleSharp.Diffing/Core/Comparison.cs
@@ -25,7 +25,9 @@ namespace AngleSharp.Diffing.Core
         /// <summary>
         /// Gets whether the control and test nodes are of the same type and has the same name.
         /// </summary>
-        public bool AreNodeTypesEqual => Control.Node.NodeType == Test.Node.NodeType && Control.Node.NodeName == Test.Node.NodeName;
+        public bool AreNodeTypesEqual
+            => Control.Node.NodeType == Test.Node.NodeType
+            && Control.Node.NodeName.Equals(Test.Node.NodeName, StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// Creates a new comparison.

--- a/src/AngleSharp.Diffing/Strategies/AttributeStrategies/DiffingStrategyPipelineBuilderExtensions.cs
+++ b/src/AngleSharp.Diffing/Strategies/AttributeStrategies/DiffingStrategyPipelineBuilderExtensions.cs
@@ -58,6 +58,7 @@ namespace AngleSharp.Diffing
         /// <summary>
         /// Enables the special style attributes comparer during diffing.
         /// </summary>
+        /// <param name="builder"></param>
         /// <param name="ignoreOrder">Then the flag is true, the comparer orders the styles in ascending order before comparing them.
         /// Therefore two styles are identical if they have the same properties and values but in different order.
         /// </param>

--- a/src/AngleSharp.Diffing/Strategies/DiffingStrategyPipelineBuilderExtensions.cs
+++ b/src/AngleSharp.Diffing/Strategies/DiffingStrategyPipelineBuilderExtensions.cs
@@ -26,8 +26,7 @@ namespace AngleSharp.Diffing
                 .AddBooleanAttributeComparer(BooleanAttributeComparision.Strict)
                 .AddStyleAttributeComparer()
                 .AddIgnoreChildrenElementSupport()
-                .AddIgnoreAttributesElementSupport()
-                ;
+                .AddIgnoreAttributesElementSupport();
         }
     }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,10 +1,10 @@
 <Project>
   <PropertyGroup>
-    <Version>0.16.0</Version>
+    <Version>0.17.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>CS8600;CS8602;CS8603;CS8625</WarningsAsErrors>
     <SignAssembly>true</SignAssembly>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="0.16.0" />
-    <PackageReference Include="AngleSharp.Css" Version="0.16.0" />
+    <PackageReference Include="AngleSharp" Version="0.17.0" />
+    <PackageReference Include="AngleSharp.Css" Version="0.17.0" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>0.17.0</Version>
+    <Version>0.17.1</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Suppose the user somehow manages to create two nodes, where one is considered unknown and thus has its node name in upper case, and the other node does not. In that case, they should still be regarded as equal, as long as their `NodeType` are identical and `NodeName` is the same (case insensitive).

Inspired by the question here: https://stackoverflow.com/questions/75335821/bunit-simple-markup-verification-for-path-tag

A simple example is this:

Let the control node be the `<path>` element found by parsing `<svg><path></path></svg>` and select the first child.
Let the test node be the result of parsing `<path/>`. This will result in an IUnknownHtmlElement being returned.

Then the element comparer should consider the control node and the test node equal.

Ps. PR also includes some housekeeping commits.